### PR TITLE
Convert a string to spinal case

### DIFF
--- a/spinalTapCase.js
+++ b/spinalTapCase.js
@@ -1,0 +1,32 @@
+// Spinal Tap Case
+// Convert a string to spinal case. Spinal case is all-lowercase-words-joined-by-dashes.
+
+function spinalCase(str) {
+    const spaces = /\s+/g
+    const camelCase = /([a-z])(?=[A-Z])/g
+    const underScore = /_/g
+  
+    // CAMELCASE - find camelcase words and separate by 1 space
+    if(camelCase.test(str)) {
+      str = str.replace(camelCase, "$1 ")
+    }
+  
+    // SPACES - find all spaces and replace with 1 dash
+    if(spaces.test(str)) {
+      str = str.replace(spaces, '-')
+    }
+  
+    // UNDERSCORE - find all underscores and replace with 1 dash
+    if(underScore.test(str)) {
+      str = str.replace(underScore, "-")
+    }
+  
+  return str.toLowerCase()
+  }
+  
+  spinalCase('The_Andy_Griffith_Show');
+  // returns "the-andy-griffith-show"
+  
+  
+  
+  


### PR DESCRIPTION
Convert a string to spinal case. Spinal case is all-lowercase-words-joined-by-dashes.

spinalCase("This Is Spinal Tap") should return the string this-is-spinal-tap.
spinalCase("thisIsSpinalTap") should return the string this-is-spinal-tap.
spinalCase("The_Andy_Griffith_Show") should return the string the-andy-griffith-show.
spinalCase("Teletubbies say Eh-oh") should return the string teletubbies-say-eh-oh.
spinalCase("AllThe-small Things") should return the string all-the-small-things.
